### PR TITLE
Radio buttons strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pnpm add astro-color-scheme
 
 ## Basic Usage
 
-You can toggle the theme using `button`, `select` or `checkbox` inside the `<ThemeSwitch>`.
+You can toggle the theme using `button`, `select`, `checkbox` or `radio` inside the `<ThemeSwitch>`.
 
 ```jsx
 ---
@@ -31,7 +31,7 @@ import { ThemeSwitch } from "astro-color-scheme";
 ```
 
 <details>
-<summary>Advanced Example</summary>
+<summary>Advanced Examples</summary>
 
 **Using Select:**
 
@@ -47,6 +47,24 @@ import { ThemeSwitch } from "astro-color-scheme";
       <option value="dark">Dark</option>
       <option value="light">Light</option>
     </select>
+  </ThemeSwitch>
+</div>
+```
+
+**Using Radio:**
+
+```jsx
+---
+import { ThemeSwitch } from "astro-color-scheme";
+---
+
+<div>
+  <ThemeSwitch strategy="radio" defaultTheme="system">
+    <form>
+      <label><input type="radio" name="theme" value="system" />System</label>
+      <label><input type="radio" name="theme" value="dark" />Dark</label>
+      <label><input type="radio" name="theme" value="light" />Light</label>
+    </form>
   </ThemeSwitch>
 </div>
 ```
@@ -74,10 +92,10 @@ Options for `ThemeSwitch`
 
 | option         | required                     | notes                                                           |
 | -------------- | ---------------------------- | --------------------------------------------------------------- |
-| `strategy`     | `required` if you use toggle | Possible values: `button`, `checkbox` or `select`               |
+| `strategy`     | `required` if you use toggle | Possible values: `button`, `checkbox`, `select` or `radio`      |
 | `defaultTheme` | `optional`                   | Default: `system`, Possible values: `light`, `dark` or `system` |
 
-Elements Allowed for Toggle inside `ThemeSwitch` are `<button>`, `checkbox` & `<select>`
+Elements Allowed for Toggle inside `ThemeSwitch` are `<button>`, `<input type=checkbox>`, `<select>`, `<form>`.
 
 ```html
 <!-- Button -->

--- a/src/ThemeSwitch.astro
+++ b/src/ThemeSwitch.astro
@@ -18,15 +18,27 @@ const { strategy, defaultTheme } = Astro.props;
 <script define:vars={{ strategy, defaultTheme }}>
   const themeSwitch = document.getElementById("astro-color-scheme-switch");
   const theme = localStorage.getItem("theme");
-  const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+  const themeMatcher = window.matchMedia("(prefers-color-scheme: dark)");
+  let systemTheme = themeMatcher.matches
     ? "dark"
     : "light";
 
-  function updateTheme(value) {
-    const theme = value === "system" ? systemTheme : value;
+  themeMatcher.addEventListener("change", (event) => {
+    const theme = event.matches ? "dark" : "light";
+    systemTheme = theme;
+    if (localStorage.getItem("theme") === "system") {
+      updateAppliedTheme(theme);
+    }
+  });
+
+  function updateAppliedTheme(value) {
     document.documentElement.classList.remove("light", "dark");
-    document.documentElement.classList.add(theme);
-    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.classList.add(value);
+    document.documentElement.setAttribute("data-theme", value); 
+  }
+
+  function updateTheme(value) {
+    updateAppliedTheme(value === "system" ? systemTheme : value)
     localStorage.setItem("theme", value);
   }
 

--- a/src/ThemeSwitch.astro
+++ b/src/ThemeSwitch.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  strategy?: "button" | "checkbox" | "select";
+  strategy?: "button" | "checkbox" | "select" | 'radio';
   defaultTheme?: "dark" | "light" | "system";
 }
 
@@ -19,9 +19,7 @@ const { strategy, defaultTheme } = Astro.props;
   const themeSwitch = document.getElementById("astro-color-scheme-switch");
   const theme = localStorage.getItem("theme");
   const themeMatcher = window.matchMedia("(prefers-color-scheme: dark)");
-  let systemTheme = themeMatcher.matches
-    ? "dark"
-    : "light";
+  let systemTheme = themeMatcher.matches ? "dark" : "light";
 
   themeMatcher.addEventListener("change", (event) => {
     const theme = event.matches ? "dark" : "light";
@@ -34,11 +32,12 @@ const { strategy, defaultTheme } = Astro.props;
   function updateAppliedTheme(value) {
     document.documentElement.classList.remove("light", "dark");
     document.documentElement.classList.add(value);
-    document.documentElement.setAttribute("data-theme", value); 
+    document.documentElement.setAttribute("data-theme", value);
   }
 
   function updateTheme(value) {
-    updateAppliedTheme(value === "system" ? systemTheme : value)
+    const theme = value === "system" ? systemTheme : value;
+    updateAppliedTheme(theme);
     localStorage.setItem("theme", value);
   }
 
@@ -49,7 +48,15 @@ const { strategy, defaultTheme } = Astro.props;
         `plugin-astro-color-scheme: <${selector}> element must be present inside 'themeSwitch' or change the 'strategy' attribute`
       );
     }
-    element.value = theme || defaultTheme || systemTheme;
+
+    if (selector === "form") {
+      element.value = theme || defaultTheme || systemTheme;
+      Array.from(element.querySelectorAll("input")).forEach((input) => {
+        input.checked = (theme || defaultTheme || systemTheme) === input.value;
+      });
+    } else {
+      element.value = theme || defaultTheme || systemTheme;
+    }
 
     if (selector === "input") {
       element.checked = defaultTheme !== element.value;
@@ -80,6 +87,11 @@ const { strategy, defaultTheme } = Astro.props;
         const settheme = checkbox.value === "dark" ? "light" : "dark";
         checkbox.value = settheme;
         updateTheme(settheme);
+      });
+      break;
+    case "radio":
+      setupThemeSwitch("form", "click", (event) => {
+        updateTheme(event.target.value);
       });
       break;
     default:

--- a/src/ThemeSwitch.astro
+++ b/src/ThemeSwitch.astro
@@ -52,7 +52,6 @@ const { strategy, defaultTheme } = Astro.props;
     element.value = theme || defaultTheme || systemTheme;
 
     if (selector === "input") {
-      console.log(element, defaultTheme, element.value);
       element.checked = defaultTheme !== element.value;
     }
 


### PR DESCRIPTION
Apologies for building on the previous PR. I can split them up, or the duplicate commits will be removed from this PR once the other is merged.

This Pr, specifically this commit: https://github.com/surjithctly/astro-color-scheme/commit/6513039c72535cfbe927340ba1ff6dc23cd6ce52

Adds an option to use a set of three radio buttons so you can have dark|light|system without using a select.