### PR TITLE
Fixes prop types in themeswitch component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-color-scheme",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Perfect dark mode for Astro in few lines of code. Theme Toggle for Dark, Light & Auto (system)",
   "type": "module",
   "exports": {

--- a/src/ThemeSwitch.astro
+++ b/src/ThemeSwitch.astro
@@ -1,11 +1,11 @@
 ---
-interface Props {
-  strategy?: "button" | "checkbox" | "select" | "radio";
-  defaultTheme?: "dark" | "light" | "system";
-  as?: "div" | "span";
-}
+type Props = Partial<{
+  as: "div" | "span";
+  defaultTheme: "dark" | "light" | "system";
+  strategy: "button" | "checkbox" | "select" | "radio";
+}>;
 
-const { strategy, defaultTheme, as: Element = "span" } = Astro.props;
+const { strategy, defaultTheme, as: Element = "span" }: Props = Astro.props;
 ---
 
 <Element id="astro-color-scheme-switch">


### PR DESCRIPTION
The props type was not actually being applied to the themeswitch component.

![image](https://github.com/surjithctly/astro-color-scheme/assets/42397676/e0faf0d1-7304-4bdd-b397-b46d5bfae0b5)

This gives the component some level of type safety / prevents the type from displaying as "Record<string, any>"

![image](https://github.com/surjithctly/astro-color-scheme/assets/42397676/1194a8d5-d80b-413c-bbd1-268c8e2a01e9)



